### PR TITLE
feat: SO_RCVBUFFORCE on UDP sockets (BLO-3856)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -26,6 +26,14 @@ type MulticastConn struct {
 	Timeout   time.Duration
 	Timestamp bool
 
+	// RcvBufBytes, if > 0, requests this size on the underlying UDP socket via
+	// SetForcedReceiveBuffer (SO_RCVBUFFORCE on Linux, SO_RCVBUF on Darwin).
+	// SO_RCVBUFFORCE requires CAP_NET_ADMIN; on EPERM it falls back to
+	// SO_RCVBUF, which is capped at 2*net.core.rmem_max.
+	RcvBufBytes int
+	// SndBufBytes is the send-side counterpart of RcvBufBytes.
+	SndBufBytes int
+
 	conn4 *ipv4.PacketConn
 	amtGw *Gateway
 }
@@ -35,7 +43,7 @@ func (mc *MulticastConn) Open() error {
 	addr := netip.AddrPortFrom(mc.GroupAddr, mc.GroupPort)
 	dstAddr := net.UDPAddrFromAddrPort(addr)
 	flags4 := ipv4.FlagDst | ipv4.FlagInterface | ipv4.FlagTTL
-	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4)
+	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4, mc.RcvBufBytes, mc.SndBufBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create conn %s on %s: %w", addr.String(), mc.IFace.Name, err)
 	}
@@ -53,9 +61,11 @@ func (mc *MulticastConn) Open() error {
 				return err
 			}
 			mc.amtGw = &Gateway{
-				RelayAddr: &mc.RelayAddr,
-				GroupAddr: dstAddr.IP,
-				MTU:       mc.IFace.MTU,
+				RelayAddr:   &mc.RelayAddr,
+				GroupAddr:   dstAddr.IP,
+				MTU:         mc.IFace.MTU,
+				RcvBufBytes: mc.RcvBufBytes,
+				SndBufBytes: mc.SndBufBytes,
 			}
 			if mc.SrcAddr.IsValid() && !mc.SrcAddr.IsUnspecified() {
 				mc.amtGw.SourceAddr = mc.SrcAddr.AsSlice()

--- a/conn_nocgo.go
+++ b/conn_nocgo.go
@@ -16,14 +16,16 @@ import (
 // This stub allows packages that reference the type to compile without CGO,
 // but all methods return errors indicating CGO is required.
 type MulticastConn struct {
-	RelayAddr net.UDPAddr
-	SrcAddr   netip.Addr
-	GroupAddr netip.Addr
-	GroupPort uint16
-	TTL       int
-	IFace     *net.Interface
-	Timeout   time.Duration
-	Timestamp bool
+	RelayAddr   net.UDPAddr
+	SrcAddr     netip.Addr
+	GroupAddr   netip.Addr
+	GroupPort   uint16
+	TTL         int
+	IFace       *net.Interface
+	Timeout     time.Duration
+	Timestamp   bool
+	RcvBufBytes int
+	SndBufBytes int
 }
 
 var errNoCGO = fmt.Errorf("multicast connections require CGO; rebuild with CGO_ENABLED=1")

--- a/gateway.go
+++ b/gateway.go
@@ -29,13 +29,17 @@ import (
 // Public fields maintain compatibility with conn.go.
 type Gateway struct {
 	// Public fields for conn.go compatibility
-	conn         *ipv4.PacketConn
-	RelayAddr    net.Addr
-	SourceAddr   net.IP
-	GroupAddr    net.IP
-	MTU          int
-	lastData     atomic.Time
-	loopErr      atomic.Error
+	conn        *ipv4.PacketConn
+	RelayAddr   net.Addr
+	SourceAddr  net.IP
+	GroupAddr   net.IP
+	MTU         int
+	// RcvBufBytes and SndBufBytes are forwarded to the AMT relay UDP socket;
+	// see MulticastConn for semantics.
+	RcvBufBytes int
+	SndBufBytes int
+	lastData    atomic.Time
+	loopErr     atomic.Error
 
 	// Internal fields
 	handle       C.amt_gateway_handle_t
@@ -63,6 +67,11 @@ func (g *Gateway) setupSocket() (*ipv4.PacketConn, error) {
 
 	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
 		return nil, fmt.Errorf("could not set socket timestamp: %w", err)
+	}
+
+	if err := applyForcedBuffers(sock, g.RcvBufBytes, g.SndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return nil, err
 	}
 
 	// Turn the socket file descriptor into an *os.File

--- a/listen_multicast_darwin.go
+++ b/listen_multicast_darwin.go
@@ -19,7 +19,7 @@ import (
 // regardless of the address you tell it to listen on. The network and address gaddr parameters
 // work like any others and if ifname is not specified it lets the OS decide
 // which interface to listen on.
-func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, ttl int, flags4 ipv4.ControlFlags) (*ipv4.PacketConn, error) {
+func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, ttl int, flags4 ipv4.ControlFlags, rcvBufBytes int, sndBufBytes int) (*ipv4.PacketConn, error) {
 
 	if gaddr == nil || gaddr.IP.To4() == nil {
 		return nil, errors.New("invalid ipv4 address")
@@ -40,6 +40,11 @@ func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, g
 	const SO_REUSEPORT = 0x0200
 	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_REUSEPORT, 1); err != nil {
 		return nil, fmt.Errorf("could not set socket reuseport: %w", err)
+	}
+
+	if err := applyForcedBuffers(sock, rcvBufBytes, sndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return nil, err
 	}
 
 	if timestamp {

--- a/listen_multicast_linux.go
+++ b/listen_multicast_linux.go
@@ -18,7 +18,7 @@ import (
 // ListenMulticastUDP4 listens for multicast UDP packets on the given address. This actually binds
 // to the IP address given vs the built-in net.ListenMulticastUDP will listen to ALL IP addresses
 // regardless of the address you tell it to listen on.
-func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, ttl int, flags4 ipv4.ControlFlags) (*ipv4.PacketConn, error) {
+func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, ttl int, flags4 ipv4.ControlFlags, rcvBufBytes int, sndBufBytes int) (*ipv4.PacketConn, error) {
 
 	if gaddr == nil || gaddr.IP.To4() == nil {
 		return nil, errors.New("invalid ipv4 address")
@@ -39,6 +39,11 @@ func ListenMulticastUDP4(network string, ifi *net.Interface, saddr netip.Addr, g
 	const SO_REUSEPORT = 0x0f
 	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_REUSEPORT, 1); err != nil {
 		return nil, fmt.Errorf("could not set socket reuseport: %w", err)
+	}
+
+	if err := applyForcedBuffers(sock, rcvBufBytes, sndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return nil, err
 	}
 
 	// Apply BPF filter if needed

--- a/managed_conn.go
+++ b/managed_conn.go
@@ -33,6 +33,11 @@ type ManagedConn struct {
 	Timeout   time.Duration
 	Timestamp bool
 
+	// RcvBufBytes and SndBufBytes are forwarded to the native multicast
+	// socket; see MulticastConn for semantics.
+	RcvBufBytes int
+	SndBufBytes int
+
 	// DRIAD discovery configuration (RFC 8777)
 	// When EnableDRIAD is true and RelayAddr is empty, discovers relay via DNS
 	EnableDRIAD bool
@@ -157,7 +162,7 @@ func (mc *ManagedConn) tryNativeMulticast() error {
 	flags4 := ipv4.FlagDst | ipv4.FlagInterface | ipv4.FlagTTL
 
 	var prog []bpf.RawInstruction
-	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4)
+	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4, mc.RcvBufBytes, mc.SndBufBytes)
 	if err != nil {
 		return err
 	}

--- a/metrics/sockbuf.go
+++ b/metrics/sockbuf.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Socket buffer clamp kinds. Cardinality is fixed at 2; do not add new kinds
+// without re-thinking what "clamped" means.
+const (
+	BufferKindReceive = "receive"
+	BufferKindSend    = "send"
+)
+
+// SocketBufferClampedTotal counts events where amt.SetForcedReceiveBuffer
+// or amt.SetForcedSendBuffer requested a buffer larger than what the kernel
+// granted — typically because the process lacks CAP_NET_ADMIN (SO_*FORCE
+// returned EPERM) AND net.core.{r,w}mem_max is below the requested size.
+//
+// The counter is paired with a slog.Warn at the same call site. The metric
+// exists so operators with log filtering / sampling can still alert on
+// silent under-provisioning of UDP socket buffers — the original BLO-3856
+// regression mode.
+//
+// Labels:
+//   - kind: "receive" or "send" (see BufferKind* constants).
+//
+// Cardinality: 2.
+var SocketBufferClampedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "amt_socket_buffer_clamped_total",
+		Help: "Socket buffer FORCE+RCVBUF/SNDBUF clamps by kind. See amt.BufferClampedError.",
+	},
+	[]string{"kind"},
+)
+
+// IncSocketBufferClamped records one clamp event for the given kind.
+// Safe to call from any goroutine.
+func IncSocketBufferClamped(kind string) {
+	SocketBufferClampedTotal.WithLabelValues(kind).Inc()
+}

--- a/sockbuf.go
+++ b/sockbuf.go
@@ -1,0 +1,54 @@
+package amt
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/blockcast/go-amt/metrics"
+)
+
+// BufferClampedError reports that a socket buffer size request was honored
+// but the resulting buffer is smaller than requested — typically because the
+// process lacks CAP_NET_ADMIN (so SO_RCVBUFFORCE/SO_SNDBUFFORCE returned
+// EPERM) AND net.core.rmem_max / net.core.wmem_max is below the request.
+// Callers can errors.As to detect this and log a warning while continuing.
+//
+// On Darwin this type exists but is never returned, since Darwin has no
+// FORCE variant — SO_RCVBUF/SO_SNDBUF is the only mechanism and any clamp
+// is invisible to userspace.
+type BufferClampedError struct {
+	Requested int
+	Got       int
+}
+
+func (e *BufferClampedError) Error() string {
+	return fmt.Sprintf("socket buffer clamped: requested %d bytes, got %d (raise net.core.rmem_max/wmem_max or grant CAP_NET_ADMIN)",
+		e.Requested, e.Got)
+}
+
+// applyForcedBuffers raises the receive and send buffers on the given socket
+// fd, treating *BufferClampedError as a non-fatal warning (logged via slog).
+// Real syscall errors (EBADF, ENOTSOCK, etc.) are returned to the caller and
+// should abort socket setup.
+func applyForcedBuffers(fd, rcvBufBytes, sndBufBytes int) error {
+	if err := SetForcedReceiveBuffer(fd, rcvBufBytes); err != nil {
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			return fmt.Errorf("could not set socket receive buffer: %w", err)
+		}
+		slog.Warn("amt: udp receive buffer clamped",
+			"requested", clamp.Requested, "got", clamp.Got)
+		metrics.IncSocketBufferClamped(metrics.BufferKindReceive)
+	}
+	if err := SetForcedSendBuffer(fd, sndBufBytes); err != nil {
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			return fmt.Errorf("could not set socket send buffer: %w", err)
+		}
+		slog.Warn("amt: udp send buffer clamped",
+			"requested", clamp.Requested, "got", clamp.Got)
+		metrics.IncSocketBufferClamped(metrics.BufferKindSend)
+	}
+	return nil
+}

--- a/sockbuf_darwin.go
+++ b/sockbuf_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package amt
+
+import "syscall"
+
+// SetForcedReceiveBuffer raises the socket receive buffer to at least bytes.
+// Darwin has no SO_RCVBUFFORCE, so this is plain SO_RCVBUF (subject to
+// kern.ipc.maxsockbuf). No-op when bytes <= 0 or when the current buffer is
+// already at least bytes.
+func SetForcedReceiveBuffer(fd int, bytes int) error {
+	return setBufferAtLeast(fd, bytes, syscall.SO_RCVBUF)
+}
+
+// SetForcedSendBuffer is the send-side counterpart of SetForcedReceiveBuffer.
+func SetForcedSendBuffer(fd int, bytes int) error {
+	return setBufferAtLeast(fd, bytes, syscall.SO_SNDBUF)
+}
+
+func setBufferAtLeast(fd, want, opt int) error {
+	if want <= 0 {
+		return nil
+	}
+	if cur, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, opt); err == nil && cur >= want {
+		return nil
+	}
+	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, opt, want)
+}

--- a/sockbuf_linux.go
+++ b/sockbuf_linux.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package amt
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// SetForcedReceiveBuffer raises the socket receive buffer so getsockopt(SO_RCVBUF)
+// reports at least bytes. It is a no-op when bytes <= 0 or when the kernel
+// already reports an allocation >= bytes (the kernel doubles the last
+// setsockopt input, so getsockopt usually shows 2× the requested value).
+//
+// It first tries SO_RCVBUFFORCE, which bypasses net.core.rmem_max but
+// requires CAP_NET_ADMIN in the socket's network namespace user namespace.
+// On EPERM it falls back to SO_RCVBUF (capped at 2*net.core.rmem_max).
+// If the fallback returns a buffer smaller than requested, the error is a
+// *BufferClampedError so callers can choose to warn-and-continue.
+func SetForcedReceiveBuffer(fd int, bytes int) error {
+	return setBufferAtLeast(fd, bytes,
+		syscall.SO_RCVBUF, syscall.SO_RCVBUFFORCE)
+}
+
+// SetForcedSendBuffer is the send-side counterpart of SetForcedReceiveBuffer.
+func SetForcedSendBuffer(fd int, bytes int) error {
+	return setBufferAtLeast(fd, bytes,
+		syscall.SO_SNDBUF, syscall.SO_SNDBUFFORCE)
+}
+
+func setBufferAtLeast(fd, want, getOpt, forceOpt int) error {
+	if want <= 0 {
+		return nil
+	}
+	// Don't shrink. getsockopt returns the kernel-allocated size (typically
+	// 2x the last setsockopt value due to internal doubling). If we already
+	// have at least `want` bytes allocated, leave it alone.
+	cur, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, getOpt)
+	if err != nil {
+		return fmt.Errorf("getsockopt baseline: %w", err)
+	}
+	if cur >= want {
+		return nil
+	}
+
+	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, forceOpt, want)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.EPERM) {
+		return err
+	}
+
+	if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, getOpt, want); err != nil {
+		return err
+	}
+	got, gerr := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, getOpt)
+	if gerr != nil {
+		return fmt.Errorf("getsockopt verify after fallback: %w", gerr)
+	}
+	if got < want {
+		return &BufferClampedError{Requested: want, Got: got}
+	}
+	return nil
+}

--- a/sockbuf_test.go
+++ b/sockbuf_test.go
@@ -1,0 +1,132 @@
+package amt
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func newUDPSocket(t *testing.T) int {
+	t.Helper()
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err != nil {
+		t.Fatalf("socket: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Close(fd) })
+	return fd
+}
+
+func TestSetForcedReceiveBufferZero(t *testing.T) {
+	fd := newUDPSocket(t)
+	before, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	if err := SetForcedReceiveBuffer(fd, 0); err != nil {
+		t.Fatalf("SetForcedReceiveBuffer(0): want nil, got %v", err)
+	}
+	if err := SetForcedReceiveBuffer(fd, -1); err != nil {
+		t.Fatalf("SetForcedReceiveBuffer(-1): want nil, got %v", err)
+	}
+	after, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	if before != after {
+		t.Errorf("buffer changed despite no-op: before=%d after=%d", before, after)
+	}
+}
+
+func TestSetForcedReceiveBufferDoesNotShrink(t *testing.T) {
+	fd := newUDPSocket(t)
+	// Set baseline first.
+	if err := SetForcedReceiveBuffer(fd, 1<<20); err != nil { // 1 MB
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			t.Fatalf("baseline set: %v", err)
+		}
+		// Clamped is OK for baseline; use whatever we got.
+	}
+	before, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	// Request a smaller buffer; helper should skip (don't shrink).
+	if err := SetForcedReceiveBuffer(fd, 1024); err != nil {
+		t.Fatalf("no-shrink call: %v", err)
+	}
+	after, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	if after < before {
+		t.Errorf("buffer was shrunk: before=%d after=%d", before, after)
+	}
+}
+
+func TestSetForcedReceiveBufferGrows(t *testing.T) {
+	fd := newUDPSocket(t)
+	before, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	// Pick a target somewhat above the default (212992*2 = ~425KB on most
+	// kernels) but well below typical rmem_max (often >= 7.5MB on modern
+	// systems, or whatever the test environment has).
+	want := before * 2
+	if want < 1<<20 {
+		want = 1 << 20
+	}
+	err := SetForcedReceiveBuffer(fd, want)
+	if err != nil {
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// On a low-rmem_max host without NET_ADMIN, the kernel clamps below
+		// `want`. The helper reports this via BufferClampedError; the buffer
+		// still grew (just not to the full request).
+		t.Logf("got clamp (expected on low-rmem_max env w/o NET_ADMIN): %v", clamp)
+	}
+	after, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	if after <= before {
+		t.Errorf("buffer did not grow: before=%d after=%d want=%d", before, after, want)
+	}
+}
+
+func TestSetForcedReceiveBufferBadFD(t *testing.T) {
+	if err := SetForcedReceiveBuffer(-1, 1<<20); err == nil {
+		t.Fatal("expected error on bad fd, got nil")
+	}
+}
+
+func TestBufferClampedErrorMessage(t *testing.T) {
+	e := &BufferClampedError{Requested: 7500000, Got: 425984}
+	if msg := e.Error(); msg == "" {
+		t.Fatal("empty error message")
+	}
+}
+
+func TestSetForcedSendBufferGrows(t *testing.T) {
+	fd := newUDPSocket(t)
+	before, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+	want := before * 2
+	if want < 1<<20 {
+		want = 1 << 20
+	}
+	err := SetForcedSendBuffer(fd, want)
+	if err != nil {
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		t.Logf("got clamp (expected on low-wmem_max env w/o NET_ADMIN): %v", clamp)
+	}
+	after, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+	if after <= before {
+		t.Errorf("send buffer did not grow: before=%d after=%d want=%d", before, after, want)
+	}
+}
+
+func TestSetForcedSendBufferDoesNotShrink(t *testing.T) {
+	fd := newUDPSocket(t)
+	if err := SetForcedSendBuffer(fd, 1<<20); err != nil {
+		var clamp *BufferClampedError
+		if !errors.As(err, &clamp) {
+			t.Fatalf("baseline set: %v", err)
+		}
+	}
+	before, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+	if err := SetForcedSendBuffer(fd, 1024); err != nil {
+		t.Fatalf("no-shrink call: %v", err)
+	}
+	after, _ := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+	if after < before {
+		t.Errorf("send buffer was shrunk: before=%d after=%d", before, after)
+	}
+}


### PR DESCRIPTION
## Summary

Add `RcvBufBytes` / `SndBufBytes` fields to `MulticastConn`, `ManagedConn`, and `Gateway`. When non-zero, the underlying UDP socket attempts `SO_RCVBUFFORCE` / `SO_SNDBUFFORCE`, falling back to plain `SO_RCVBUF` / `SO_SNDBUF` on `EPERM`.

The reason this matters: `SO_RCVBUFFORCE` bypasses `net.core.rmem_max` but requires `CAP_NET_ADMIN` in the socket netns user namespace. With this in place, a containerized multicast process can opt into a large UDP receive buffer **without running on `hostNetwork`**. That's what unblocks dropping `hostNetwork: true` from the on-prem ARC runner pool that exercises multicast integration tests (today carrying a `c925e9f` `requiredDuringScheduling` anti-affinity to work around hostNetwork port collisions).

## Behavior

| Input | Outcome |
|---|---|
| `bytes <= 0` | no-op (preserves current zero-value default) |
| current buffer ≥ `bytes` | skip (don't shrink) |
| FORCE succeeds | silent |
| FORCE EPERM + RCVBUF clamps below `bytes` | returns `*BufferClampedError`; the `applyForcedBuffers` wrapper logs a `slog.Warn` and continues |
| Real syscall errors (EBADF, ENOTSOCK, …) | propagate up |

Verified empirically on a `kernel 6.8` paperclip ARC node:

```
=== BASELINE (no NET_ADMIN) ===
CapEff: 00000000a80425fb
SO_RCVBUFFORCE: FAIL errno=1 Operation not permitted
SO_RCVBUF: want=7500000 got=15000000

=== WITH NET_ADMIN ===
CapEff: 00000000a80435fb
SO_RCVBUFFORCE: OK want=7500000 got=15000000
```

## API change

`ListenMulticastUDP4` gains trailing `rcvBufBytes, sndBufBytes int` params on both Linux and Darwin. Only two direct callers exist (`conn.go`, `managed_conn.go`); all external consumers use `MulticastConn{}` / `ManagedConn{}` struct literals and pick up the new fields via struct composition (zero-value safe).

## Tests

- 5 new unit tests covering: zero/negative no-op, don't-shrink, grows on demand, bad fd, error message
- All pass: `go test -run 'TestSet|TestBuffer' -v ./.` → PASS
- `go vet ./...` clean on both Linux and Darwin (`GOOS=darwin go vet ./...` clean)
- Pre-existing `e2e_test.go` requires a live AMT relay and is unaffected by this change

## Test plan
- [x] `go vet` clean on Linux and Darwin
- [x] Unit tests pass
- [x] Empirical pod smoke confirms `SO_RCVBUFFORCE` works with `CAP_NET_ADMIN` on the target kernel
- [ ] Multicast bump + integration test pass in follow-up PR
- [ ] On-prem ARC pool drops `hostNetwork` in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)