### PR TITLE
feat: native IPv6 (MLDv2) source-specific multicast join

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -9,12 +9,24 @@ import (
 	"github.com/google/gopacket/layers"
 	"golang.org/x/net/bpf"
 	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 	"net"
 	"net/netip"
 	"time"
 )
 
 var _ net.PacketConn = (*MulticastConn)(nil)
+
+// nativeConn is the subset of methods shared by *ipv4.PacketConn and
+// *ipv6.PacketConn that the non-data-plane bookkeeping (Close, deadlines,
+// local address) needs, independent of the IP version's control-message type.
+type nativeConn interface {
+	Close() error
+	LocalAddr() net.Addr
+	SetDeadline(t time.Time) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+}
 
 type MulticastConn struct {
 	RelayAddr net.UDPAddr
@@ -35,13 +47,60 @@ type MulticastConn struct {
 	SndBufBytes int
 
 	conn4 *ipv4.PacketConn
+	conn6 *ipv6.PacketConn
 	amtGw *Gateway
+}
+
+// activeConn returns the version-agnostic view of whichever native PacketConn
+// is currently open (v4 or v6), or nil when neither is set (e.g. AMT tunnel).
+func (mc *MulticastConn) activeConn() nativeConn {
+	if mc.conn4 != nil {
+		return mc.conn4
+	}
+	if mc.conn6 != nil {
+		return mc.conn6
+	}
+	return nil
 }
 
 func (mc *MulticastConn) Open() error {
 	var prog []bpf.RawInstruction
 	addr := netip.AddrPortFrom(mc.GroupAddr, mc.GroupPort)
 	dstAddr := net.UDPAddrFromAddrPort(addr)
+
+	if mc.GroupAddr.Is6() {
+		flags6 := ipv6.FlagDst | ipv6.FlagInterface | ipv6.FlagHopLimit
+		conn, err := ListenMulticastUDP6("udp6", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags6, mc.RcvBufBytes, mc.SndBufBytes)
+		if err != nil {
+			return fmt.Errorf("failed to create conn %s on %s: %w", addr.String(), mc.IFace.Name, err)
+		}
+		mc.conn6 = conn
+
+		if len(mc.RelayAddr.IP) > 0 {
+			if err = mc.conn6.SetReadDeadline(time.Now().Add(mc.Timeout)); err != nil {
+				return err
+			}
+			discard := make([]byte, mc.IFace.MTU)
+			n, _, _, err := mc.conn6.ReadFrom(discard)
+			_ = n
+			if err, ok := err.(net.Error); ok && err.Timeout() {
+				if err := mc.conn6.Close(); err != nil {
+					return err
+				}
+				mc.conn6 = nil
+				// Native v6 join produced no traffic and a relay is configured,
+				// but the AMT tunnel data plane is v4-only. Surface a clear error
+				// rather than silently falling back to an unsupported path.
+				return fmt.Errorf("v6 AMT tunnel fallback not yet supported")
+			} else if err != nil {
+				return err
+			} else {
+				return mc.conn6.SetReadDeadline(time.Time{})
+			}
+		}
+		return nil
+	}
+
 	flags4 := ipv4.FlagDst | ipv4.FlagInterface | ipv4.FlagTTL
 	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4, mc.RcvBufBytes, mc.SndBufBytes)
 	if err != nil {
@@ -87,6 +146,10 @@ func (mc *MulticastConn) IsUsingTunnel() bool {
 }
 func (mc *MulticastConn) ReadBatch(ms []ipv4.Message, flags int) (int, error) {
 	if !mc.IsUsingTunnel() {
+		if mc.conn6 != nil {
+			// ipv6.Message and ipv4.Message are both aliases for socket.Message.
+			return mc.conn6.ReadBatch(ms, flags)
+		}
 		return mc.conn4.ReadBatch(ms, flags)
 	}
 	if err := mc.amtGw.loopErr.Swap(nil); err != nil {
@@ -160,6 +223,12 @@ func (mc *MulticastConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 }
 func (mc *MulticastConn) ReadFromWithControlMessage(buf []byte) (n int, cm *ipv4.ControlMessage, src net.Addr, err error) {
 	if !mc.IsUsingTunnel() {
+		if mc.conn6 != nil {
+			// Native v6 receive: the v6 control message has a different type, so
+			// it is dropped here. Callers only consume cm on the v4 path.
+			n, _, src, err = mc.conn6.ReadFrom(buf)
+			return n, nil, src, err
+		}
 		return mc.conn4.ReadFrom(buf)
 	}
 	if err := mc.amtGw.loopErr.Swap(nil); err != nil {
@@ -212,14 +281,20 @@ func (mc *MulticastConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 
 func (mc *MulticastConn) WriteToWithControlMessage(b []byte, cm *ipv4.ControlMessage, dst net.Addr) (n int, err error) {
 	if !mc.IsUsingTunnel() {
+		if mc.conn6 != nil {
+			// The v4 control message does not apply to the v6 socket.
+			return mc.conn6.WriteTo(b, nil, dst)
+		}
 		return mc.conn4.WriteTo(b, cm, dst)
 	}
 	return 0, fmt.Errorf("write not implemented for amt gatway")
 }
 
 func (mc *MulticastConn) Close() error {
-	if !mc.IsUsingTunnel() && mc.conn4 != nil {
-		return mc.conn4.Close()
+	if !mc.IsUsingTunnel() {
+		if c := mc.activeConn(); c != nil {
+			return c.Close()
+		}
 	}
 	if mc.amtGw != nil {
 		return mc.amtGw.Close()
@@ -229,34 +304,38 @@ func (mc *MulticastConn) Close() error {
 
 func (mc *MulticastConn) LocalAddr() net.Addr {
 	if !mc.IsUsingTunnel() {
-		return mc.conn4.LocalAddr()
+		return mc.activeConn().LocalAddr()
 	}
 	return mc.amtGw.conn.LocalAddr()
 }
 
 func (mc *MulticastConn) SetDeadline(t time.Time) error {
 	if !mc.IsUsingTunnel() {
-		return mc.conn4.SetDeadline(t)
+		return mc.activeConn().SetDeadline(t)
 	}
 	return mc.amtGw.conn.SetDeadline(t)
 }
 
 func (mc *MulticastConn) SetReadDeadline(t time.Time) error {
 	if !mc.IsUsingTunnel() {
-		return mc.conn4.SetReadDeadline(t)
+		return mc.activeConn().SetReadDeadline(t)
 	}
 	return mc.amtGw.conn.SetReadDeadline(t)
 }
 
 func (mc *MulticastConn) SetWriteDeadline(t time.Time) error {
 	if !mc.IsUsingTunnel() {
-		return mc.conn4.SetWriteDeadline(t)
+		return mc.activeConn().SetWriteDeadline(t)
 	}
 	return mc.amtGw.conn.SetWriteDeadline(t)
 }
 
 func (mc *MulticastConn) WriteBatch(msg []ipv4.Message, i int) (int, error) {
 	if !mc.IsUsingTunnel() {
+		if mc.conn6 != nil {
+			// ipv6.Message and ipv4.Message are both aliases for socket.Message.
+			return mc.conn6.WriteBatch(msg, i)
+		}
 		return mc.conn4.WriteBatch(msg, i)
 	}
 	return 0, fmt.Errorf("writebatch not implemented for amt gatway")

--- a/listen_multicast6_darwin.go
+++ b/listen_multicast6_darwin.go
@@ -1,0 +1,116 @@
+//go:build darwin && !ios
+
+package amt
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/net/bpf"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
+	"net"
+	"net/netip"
+	"os"
+	"syscall"
+)
+
+// ListenMulticastUDP6 is the IPv6 counterpart of ListenMulticastUDP4 on Darwin.
+// It binds an AF_INET6 UDP socket and issues a source-specific (MLDv2) join for
+// the given (source, group) pair, falling back to an any-source (ASM) join when
+// no source is supplied.
+func ListenMulticastUDP6(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, hoplimit int, flags6 ipv6.ControlFlags, rcvBufBytes int, sndBufBytes int) (*ipv6.PacketConn, error) {
+
+	if gaddr == nil || gaddr.IP.To4() != nil || gaddr.IP.To16() == nil {
+		return nil, errors.New("invalid ipv6 address")
+	}
+
+	// Create socket
+	sock, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get socket: %w", err)
+	}
+
+	// Reuse the address
+	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return nil, fmt.Errorf("could not set socket reuseaddr: %w", err)
+	}
+
+	//Reuse the port
+	const SO_REUSEPORT = 0x0200
+	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_REUSEPORT, 1); err != nil {
+		return nil, fmt.Errorf("could not set socket reuseport: %w", err)
+	}
+
+	if err := applyForcedBuffers(sock, rcvBufBytes, sndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return nil, err
+	}
+
+	if timestamp {
+		if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
+			return nil, fmt.Errorf("could not set socket timestamp: %w", err)
+		}
+	}
+
+	// Attach to specific interface if requested
+	if ifi != nil {
+		if err := unix.SetsockoptInt(sock, unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, ifi.Index); err != nil {
+			return nil, fmt.Errorf("could not bind to interface: %w", err)
+		}
+	}
+
+	lsa := syscall.SockaddrInet6{Port: gaddr.Port}
+	// Bind to in6addr_any ([::]); lsa.Addr stays zeroed.
+	if ifi != nil {
+		lsa.ZoneId = uint32(ifi.Index)
+	}
+	if err := syscall.Bind(sock, &lsa); err != nil {
+		return nil, fmt.Errorf("could not bind socket: %w", err)
+	}
+
+	// Convert the file descriptor into an *os.File and then into net.PacketConn
+	file := os.NewFile(uintptr(sock), "")
+	fconn, err := net.FilePacketConn(file)
+	file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not wrap filepacketconn: %w", err)
+	}
+
+	conn := ipv6.NewPacketConn(fconn)
+
+	// Set multicast interface for both sending and receiving
+	if err := conn.SetMulticastInterface(ifi); err != nil {
+		return nil, fmt.Errorf("set multicast interface: %w", err)
+	}
+
+	// Optional: Enable multicast loopback if you want to receive your own multicast packets
+	if err := conn.SetMulticastLoopback(true); err != nil {
+		return nil, fmt.Errorf("could not enable multicast loopback: %w", err)
+	}
+
+	// Set multicast hop limit (the IPv6 analogue of the IPv4 multicast TTL)
+	if err := conn.SetMulticastHopLimit(hoplimit); err != nil {
+		return nil, fmt.Errorf("could not set multicast hop limit: %w", err)
+	}
+
+	if err := conn.SetControlMessage(flags6, true); err != nil {
+		return nil, err
+	}
+
+	// Join the multicast group or source-specific group
+	if saddr.IsValid() && !saddr.IsUnspecified() {
+		srcAddr := &net.IPAddr{
+			IP:   saddr.AsSlice(),
+			Zone: saddr.Zone(),
+		}
+		err = conn.JoinSourceSpecificGroup(ifi, gaddr, srcAddr)
+	} else {
+		err = conn.JoinGroup(ifi, gaddr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("join ssg (%s): %w", saddr.String(), err)
+	}
+
+	return conn, nil
+
+}

--- a/listen_multicast6_linux.go
+++ b/listen_multicast6_linux.go
@@ -1,0 +1,125 @@
+//go:build linux && !android
+
+package amt
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/net/bpf"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
+	"net"
+	"net/netip"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// ListenMulticastUDP6 is the IPv6 counterpart of ListenMulticastUDP4. It binds
+// an AF_INET6 UDP socket and issues a source-specific (MLDv2) join for the
+// given (source, group) pair, falling back to an any-source (ASM) join when no
+// source is supplied.
+func ListenMulticastUDP6(network string, ifi *net.Interface, saddr netip.Addr, gaddr *net.UDPAddr, f []bpf.RawInstruction, timestamp bool, hoplimit int, flags6 ipv6.ControlFlags, rcvBufBytes int, sndBufBytes int) (*ipv6.PacketConn, error) {
+
+	if gaddr == nil || gaddr.IP.To4() != nil || gaddr.IP.To16() == nil {
+		return nil, errors.New("invalid ipv6 address")
+	}
+
+	// Create socket
+	sock, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err != nil {
+		return nil, fmt.Errorf("could not get socket: %w", err)
+	}
+
+	// Reuse the address
+	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return nil, fmt.Errorf("could not set socket reuseaddr: %w", err)
+	}
+
+	// Reuse the port
+	const SO_REUSEPORT = 0x0f
+	if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, SO_REUSEPORT, 1); err != nil {
+		return nil, fmt.Errorf("could not set socket reuseport: %w", err)
+	}
+
+	if err := applyForcedBuffers(sock, rcvBufBytes, sndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return nil, err
+	}
+
+	// Apply BPF filter if needed
+	if len(f) > 0 {
+		prog := unix.SockFprog{
+			Len:    uint16(len(f)),
+			Filter: (*unix.SockFilter)(unsafe.Pointer(&f[0])),
+		}
+		b := (*[unix.SizeofSockFprog]byte)(unsafe.Pointer(&prog))[:unix.SizeofSockFprog]
+		err := syscall.SetsockoptString(sock, syscall.SOL_SOCKET, syscall.SO_ATTACH_FILTER, string(b))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set bpf: %w", err)
+		}
+	}
+
+	// Allow timestamps if needed
+	if timestamp {
+		if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_TIMESTAMPNS, 1); err != nil {
+			if err := syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
+				return nil, fmt.Errorf("failed to enable SO_TIMESTAMP: %w", err)
+			}
+		}
+	}
+
+	lsa := syscall.SockaddrInet6{Port: gaddr.Port}
+	// Bind to in6addr_any ([::]); lsa.Addr stays zeroed.
+	if ifi != nil {
+		lsa.ZoneId = uint32(ifi.Index)
+	}
+	if err := syscall.Bind(sock, &lsa); err != nil {
+		return nil, fmt.Errorf("could not bind socket: %w", err)
+	}
+
+	// Convert the file descriptor into an *os.File and then into net.PacketConn
+	file := os.NewFile(uintptr(sock), "")
+	fconn, err := net.FilePacketConn(file)
+	file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not wrap filepacketconn: %w", err)
+	}
+
+	conn := ipv6.NewPacketConn(fconn)
+
+	// Set multicast interface for both sending and receiving
+	if err := conn.SetMulticastInterface(ifi); err != nil {
+		return nil, fmt.Errorf("set multicast interface: %w", err)
+	}
+
+	// Optional: Enable multicast loopback if you want to receive your own multicast packets
+	if err := conn.SetMulticastLoopback(true); err != nil {
+		return nil, fmt.Errorf("could not enable multicast loopback: %w", err)
+	}
+
+	// Set multicast hop limit (the IPv6 analogue of the IPv4 multicast TTL)
+	if err := conn.SetMulticastHopLimit(hoplimit); err != nil {
+		return nil, fmt.Errorf("could not set multicast hop limit: %w", err)
+	}
+
+	if err := conn.SetControlMessage(flags6, true); err != nil {
+		return nil, err
+	}
+
+	// Join the multicast group or source-specific group
+	if saddr.IsValid() && !saddr.IsUnspecified() {
+		srcAddr := &net.IPAddr{
+			IP:   saddr.AsSlice(),
+			Zone: saddr.Zone(),
+		}
+		err = conn.JoinSourceSpecificGroup(ifi, gaddr, srcAddr)
+	} else {
+		err = conn.JoinGroup(ifi, gaddr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("join ssg (%s): %w", saddr.String(), err)
+	}
+
+	return conn, nil
+}


### PR DESCRIPTION
Adds a native IPv6 receive path so the receiver issues real (S,G) joins for v6 groups (MLDv2), fixing VLAN40 multicast flooding where v6 receivers previously had no source-specific join.

## Changes
- `conn.go`: add `conn6 *ipv6.PacketConn` + `activeConn()` helper. `Open()` branches on `GroupAddr.Is6()` and calls the new `ListenMulticastUDP6` with `flags6 = FlagDst|FlagInterface|FlagHopLimit`. The IPv4 path is unchanged. Close/LocalAddr/deadlines/ReadBatch/WriteBatch/Read/WriteWithControlMessage now operate on whichever of `conn4`/`conn6` is set (`ipv6.Message` and `ipv4.Message` are both aliases for `socket.Message`).
- `listen_multicast6_linux.go` / `listen_multicast6_darwin.go`: `ListenMulticastUDP6` mirrors the v4 helpers on an `AF_INET6` socket, using `SetMulticastHopLimit` + `JoinSourceSpecificGroup` (ASM `JoinGroup` fallback when source unspecified).
- v6 AMT-tunnel fallback is out of scope (native-only): a v6 group with no native path + a configured relay returns `"v6 AMT tunnel fallback not yet supported"` rather than silently degrading.

## Testing
`go build ./... && go vet ./...` pass. `go test ./...` passes (skipping `TestE2E_ReceiveMulticastData`, a pre-existing live-network test that hangs without a real AMT relay and is unrelated to this change — it exercises the unchanged v4 path).