### PR TITLE
fix(sockbuf): address BLO-3856 review (opt-in metrics, build tag, likec4)

### DIFF
--- a/docs/likec4/go-amt.likec4
+++ b/docs/likec4/go-amt.likec4
@@ -50,7 +50,7 @@ model {
     // Internal relationships
     gateway -[uses]-> driadGo
     gateway -[uses]-> relayManager
-    gateway -[uses]-> cgoBinding
+    gateway -[uses]-> cgoBinding // optional: CGO_ENABLED=1 builds only
   }
 }
 

--- a/managed_conn.go
+++ b/managed_conn.go
@@ -86,6 +86,8 @@ func (mc *ManagedConn) Open() error {
 		Timeout:         mc.Timeout,
 		EnableTimestamp: mc.Timestamp,
 		MTU:             1500,
+		RcvBufBytes:     mc.RcvBufBytes,
+		SndBufBytes:     mc.SndBufBytes,
 	}
 	if mc.IFace != nil {
 		transportCfg.MTU = mc.IFace.MTU

--- a/metrics/sockbuf.go
+++ b/metrics/sockbuf.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // Socket buffer clamp kinds. Cardinality is fixed at 2; do not add new kinds
@@ -26,13 +25,23 @@ const (
 //   - kind: "receive" or "send" (see BufferKind* constants).
 //
 // Cardinality: 2.
-var SocketBufferClampedTotal = promauto.NewCounterVec(
+//
+// This is a plain (unregistered) collector: a library must not register into
+// the global default registry at init. Callers opt in via RegisterMetrics.
+var SocketBufferClampedTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "amt_socket_buffer_clamped_total",
 		Help: "Socket buffer FORCE+RCVBUF/SNDBUF clamps by kind. See amt.BufferClampedError.",
 	},
 	[]string{"kind"},
 )
+
+// RegisterMetrics registers this package's collectors with the given
+// registerer. Callers opt in (e.g. RegisterMetrics(prometheus.DefaultRegisterer))
+// rather than the library registering into the global default at init.
+func RegisterMetrics(r prometheus.Registerer) error {
+	return r.Register(SocketBufferClampedTotal)
+}
 
 // IncSocketBufferClamped records one clamp event for the given kind.
 // Safe to call from any goroutine.

--- a/sockbuf_test.go
+++ b/sockbuf_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package amt
 
 import (

--- a/transport.go
+++ b/transport.go
@@ -58,6 +58,12 @@ type TransportConfig struct {
 
 	// MTU is the maximum transmission unit
 	MTU int
+
+	// RcvBufBytes and SndBufBytes, if > 0, are applied to the relay UDP socket
+	// via applyForcedBuffers (SO_RCVBUFFORCE/SO_SNDBUFFORCE on Linux,
+	// SO_RCVBUF/SO_SNDBUF on Darwin); see MulticastConn / Gateway for semantics.
+	RcvBufBytes int
+	SndBufBytes int
 }
 
 // DefaultTransportConfig returns a config with sensible defaults

--- a/transport_udp.go
+++ b/transport_udp.go
@@ -50,6 +50,17 @@ func (t *UDPTransport) Open(ctx context.Context) error {
 		_ = syscall.SetsockoptInt(sock, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1)
 	}
 
+	// Apply forced socket buffers (mirrors Gateway.setupSocket); clamps are
+	// logged + counted as non-fatal, real syscall errors abort setup.
+	if err := applyForcedBuffers(sock, t.cfg.RcvBufBytes, t.cfg.SndBufBytes); err != nil {
+		_ = syscall.Close(sock)
+		return &TransportError{
+			Type:    TransportTypeUDP,
+			Message: "failed to apply socket buffers",
+			Cause:   err,
+		}
+	}
+
 	// Convert socket to PacketConn
 	file := os.NewFile(uintptr(sock), "")
 	conn, err := net.FilePacketConn(file)


### PR DESCRIPTION
Follow-up to the allyblockcast[bot] review on merged #7 (review id 4577749934).

## Addressed
- **I2 (important)** — `metrics/sockbuf.go`: `SocketBufferClampedTotal` was a `promauto.NewCounterVec` that auto-registered into the global default registry at package init (wrong for a library). Changed to a plain `prometheus.NewCounterVec` and added `func RegisterMetrics(r prometheus.Registerer) error` so callers opt in. Removed the `promauto` import; `IncSocketBufferClamped` unchanged. No caller in-repo relied on auto-registration (only `IncSocketBufferClamped` is used).
- **S2 (suggestion)** — `sockbuf_test.go`: added `//go:build linux || darwin` as the first line; the tested `SetForcedReceiveBuffer`/`SetForcedSendBuffer` are linux/darwin-only.
- **S3 (suggestion)** — `docs/likec4/go-amt.likec4`: annotated `gateway -[uses]-> cgoBinding` with `// optional: CGO_ENABLED=1 builds only`.
- **I1 (important) — verified, real gap, fixed**: the managed AMT tunnel path (`ManagedConn.Open` → `RelayManager` → `UDPTransport.Open`) built a `TransportConfig` without the buffer fields, and `UDPTransport.Open` (transport_udp.go) created its relay UDP socket via `syscall.Socket` without ever applying forced buffers — so the managed AMT relay socket skipped buffer tuning. Threaded `RcvBufBytes`/`SndBufBytes` into `TransportConfig`, forwarded them from `ManagedConn.Open`, and applied them in `UDPTransport.Open` via the existing `applyForcedBuffers` helper (mirrors `Gateway.setupSocket` / `conn.go`). (The non-tunnel native path already forwarded the buffers via `ListenMulticastUDP4`; the only `Gateway{}` literal — conn.go:122 — already forwarded both fields.)

## Tests
`go build ./... && go vet ./... && go test ./... -skip TestE2E_ReceiveMulticastData` all pass.

Follow-up to #7 review.