### PR TITLE
fix: compile managed conn on mobile platforms

### DIFF
--- a/managed_conn.go
+++ b/managed_conn.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	m "github.com/blockcast/go-amt/messages"
-	"golang.org/x/net/bpf"
 	"golang.org/x/net/ipv4"
 )
 
@@ -44,13 +43,13 @@ type ManagedConn struct {
 	DNSServers  []string // Optional, uses system default if empty
 
 	// Internal state
-	rm           *RelayManager
-	sub          *Subscription
-	readBuffer   chan *DataPacket
-	mu           sync.RWMutex
-	closed       bool
-	usingTunnel  bool
-	localAddr    net.Addr
+	rm          *RelayManager
+	sub         *Subscription
+	readBuffer  chan *DataPacket
+	mu          sync.RWMutex
+	closed      bool
+	usingTunnel bool
+	localAddr   net.Addr
 
 	// For native multicast fallback
 	nativeConn *ipv4.PacketConn
@@ -154,48 +153,6 @@ func (mc *ManagedConn) Open() error {
 	}
 	mc.sub = sub
 
-	return nil
-}
-
-// tryNativeMulticast attempts to join the multicast group natively
-func (mc *ManagedConn) tryNativeMulticast() error {
-	addr := netip.AddrPortFrom(mc.GroupAddr, mc.GroupPort)
-	dstAddr := net.UDPAddrFromAddrPort(addr)
-	flags4 := ipv4.FlagDst | ipv4.FlagInterface | ipv4.FlagTTL
-
-	var prog []bpf.RawInstruction
-	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4, mc.RcvBufBytes, mc.SndBufBytes)
-	if err != nil {
-		return err
-	}
-
-	// If relay is configured, test if we receive packets
-	if len(mc.RelayAddr.IP) > 0 && mc.Timeout > 0 {
-		if err := conn.SetReadDeadline(time.Now().Add(mc.Timeout)); err != nil {
-			conn.Close()
-			return err
-		}
-		discard := make([]byte, 1500)
-		if mc.IFace != nil {
-			discard = make([]byte, mc.IFace.MTU)
-		}
-		_, _, _, err := conn.ReadFrom(discard)
-		if err != nil {
-			conn.Close()
-			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				return err // Timeout - need to use AMT
-			}
-			return err
-		}
-		// Reset deadline for normal operation
-		if err := conn.SetReadDeadline(time.Time{}); err != nil {
-			conn.Close()
-			return err
-		}
-	}
-
-	mc.nativeConn = conn
-	mc.localAddr = conn.LocalAddr()
 	return nil
 }
 

--- a/managed_conn_native.go
+++ b/managed_conn_native.go
@@ -1,0 +1,54 @@
+//go:build (linux || darwin) && !ios && !android
+
+package amt
+
+import (
+	"net"
+	"net/netip"
+	"time"
+
+	"golang.org/x/net/bpf"
+	"golang.org/x/net/ipv4"
+)
+
+// tryNativeMulticast attempts to join the multicast group natively.
+func (mc *ManagedConn) tryNativeMulticast() error {
+	addr := netip.AddrPortFrom(mc.GroupAddr, mc.GroupPort)
+	dstAddr := net.UDPAddrFromAddrPort(addr)
+	flags4 := ipv4.FlagDst | ipv4.FlagInterface | ipv4.FlagTTL
+
+	var prog []bpf.RawInstruction
+	conn, err := ListenMulticastUDP4("udp4", mc.IFace, mc.SrcAddr, dstAddr, prog, mc.Timestamp, mc.TTL, flags4, mc.RcvBufBytes, mc.SndBufBytes)
+	if err != nil {
+		return err
+	}
+
+	// If relay is configured, test if we receive packets.
+	if len(mc.RelayAddr.IP) > 0 && mc.Timeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(mc.Timeout)); err != nil {
+			conn.Close()
+			return err
+		}
+		discard := make([]byte, 1500)
+		if mc.IFace != nil {
+			discard = make([]byte, mc.IFace.MTU)
+		}
+		_, _, _, err := conn.ReadFrom(discard)
+		if err != nil {
+			conn.Close()
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				return err // Timeout - need to use AMT.
+			}
+			return err
+		}
+		// Reset deadline for normal operation.
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			conn.Close()
+			return err
+		}
+	}
+
+	mc.nativeConn = conn
+	mc.localAddr = conn.LocalAddr()
+	return nil
+}

--- a/managed_conn_non_native.go
+++ b/managed_conn_non_native.go
@@ -1,0 +1,9 @@
+//go:build (!linux && !darwin) || ios || android
+
+package amt
+
+import "fmt"
+
+func (mc *ManagedConn) tryNativeMulticast() error {
+	return fmt.Errorf("native multicast is not supported on this platform")
+}


### PR DESCRIPTION
## Summary

- Move native multicast probing out of platform-neutral `managed_conn.go`.
- Keep the existing native path on Linux/macOS host builds.
- Add an Android/iOS-safe stub so gomobile builds do not pull in native multicast helpers.

## Verification

- `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go test -exec=/usr/bin/true ./...`
- `go test ./messages ./metrics`
- `go test -run 'TestDRIAD|TestRelayManager|TestSubscription|TestManagedConn|TestParse|TestBuild|TestEncode|TestDecode|TestRoundTrip|TestMetric' .`
