### PR TITLE
fix: keep DRIAD AMT reachable on mobile

### DIFF
--- a/managed_conn.go
+++ b/managed_conn.go
@@ -64,15 +64,18 @@ func (mc *ManagedConn) Open() error {
 		return fmt.Errorf("connection already closed")
 	}
 
+	hasRelay := len(mc.RelayAddr.IP) > 0
+	useDRIAD := mc.EnableDRIAD && !hasRelay
+
 	// Try native multicast first (if relay timeout is configured)
-	if len(mc.RelayAddr.IP) > 0 && mc.Timeout > 0 {
+	if hasRelay && mc.Timeout > 0 {
 		if err := mc.tryNativeMulticast(); err == nil {
 			mc.usingTunnel = false
 			return nil
 		}
 		// Native multicast failed or timed out, use AMT relay
-	} else if len(mc.RelayAddr.IP) == 0 {
-		// No relay configured, use native multicast only
+	} else if !hasRelay && !useDRIAD {
+		// No relay or DRIAD discovery configured, use native multicast only.
 		return mc.tryNativeMulticast()
 	}
 
@@ -94,7 +97,7 @@ func (mc *ManagedConn) Open() error {
 
 	// Get or create RelayManager for this relay
 	var config RelayManagerConfig
-	if mc.EnableDRIAD && len(mc.RelayAddr.IP) == 0 {
+	if useDRIAD {
 		// Use DRIAD discovery
 		config = DefaultRelayManagerConfigWithDRIAD(mc.SrcAddr)
 		config.DNSServers = mc.DNSServers
@@ -105,7 +108,7 @@ func (mc *ManagedConn) Open() error {
 
 	// For DRIAD, use source address as registry key since relay is unknown
 	registryKey := mc.RelayAddr
-	if mc.EnableDRIAD && len(mc.RelayAddr.IP) == 0 {
+	if useDRIAD {
 		// Use a placeholder key based on source address for DRIAD
 		registryKey = net.UDPAddr{
 			IP:   mc.SrcAddr.AsSlice(),


### PR DESCRIPTION
## Summary

- Do not treat `RelayAddr == empty` as native-only when `EnableDRIAD` is set.
- Keep native-only behavior for the true no-relay/no-DRIAD case.
- Let mobile platforms skip native multicast while still entering RelayManager for AMT/DRIAD.

## Verification

- `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go test -exec=/usr/bin/true ./...`
- `go test -run 'TestDRIAD|TestRelayManager|TestManagedConn|TestParse|TestBuild|TestEncode|TestDecode|TestRoundTrip|TestMetric' . ./messages ./metrics`
